### PR TITLE
fix: exclude junit-platform-launcher from unit-pioneer dependency 

### DIFF
--- a/blue-green-state-monitor-java/pom.xml
+++ b/blue-green-state-monitor-java/pom.xml
@@ -68,6 +68,12 @@
             <artifactId>junit-pioneer</artifactId>
             <version>2.3.0</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.platform</groupId>
+                    <artifactId>junit-platform-launcher</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
junit-platform-launcher 1.11.2 not compatible with junit-jupiter 5.12.2